### PR TITLE
Fix join() passing glue after array deprecation.

### DIFF
--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -245,7 +245,7 @@
             $('.stack-content').each(function() {
                 var $this = $(this);
                 var html = $this.html().trim()
-                    .replace(/({!! join(log_styler()->toHighlight(), '|') !!})/gm, '<strong>$1</strong>');
+                    .replace(/({!! join('|', log_styler()->toHighlight()) !!})/gm, '<strong>$1</strong>');
 
                 $this.html(html);
             });


### PR DESCRIPTION
As of PHP 7.4 passing the glue after the array has been deprecated, this fixes that.